### PR TITLE
Use NEXT_PUBLIC_BASE_URL for public config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,11 @@ FROM base AS builder
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Declare build arguments for Next.js public variables
-ARG NEXT_PUBLIC_API_URL
-ARG NEXT_PUBLIC_VAPID_PUBLIC_KEY
+# Declare build arguments for Next.js public variables (inlined at build time)
+ARG NEXT_PUBLIC_BASE_URL
 
 # Set environment variables from build args (baked into the client bundle)
-ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
-ENV NEXT_PUBLIC_VAPID_PUBLIC_KEY=$NEXT_PUBLIC_VAPID_PUBLIC_KEY
+ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
 
 # Copy package files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-}
-        - NEXT_PUBLIC_VAPID_PUBLIC_KEY=${NEXT_PUBLIC_VAPID_PUBLIC_KEY:-}
+        # NEXT_PUBLIC_* vars are inlined into the bundle at build time
+        - NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL:-}
     ports:
       - "${APP_PORT:-3000}:3000"
     environment:
@@ -23,8 +23,9 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
-      # Public runtime config
-      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-}
+      # Public config (also passed as a build arg above, where it is inlined;
+      # kept here for the server-side runtime fallback)
+      - NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL:-}
     command: node server.js
     healthcheck:
       test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1"]

--- a/example.env
+++ b/example.env
@@ -14,8 +14,10 @@ JWT_SECRET=generate-a-strong-secret
 GOOGLE_CLIENT_ID=your-google-oauth-client-id
 GOOGLE_CLIENT_SECRET=your-google-oauth-client-secret
 
-# --- Public runtime config (baked into the client bundle at build time) ---
-NEXT_PUBLIC_API_URL=http://localhost:3000
+# --- Public config (inlined into the bundle at build time) ---
+# Base origin of the deployed app, used to build absolute API URLs
+# server-side. No trailing slash and no /api suffix (the code appends the path).
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
 # --- Docker/Coolify ---
 # Host port the container's 3000 is published on


### PR DESCRIPTION
## What
Replaces the scaffolded `NEXT_PUBLIC_API_URL` / `NEXT_PUBLIC_VAPID_PUBLIC_KEY` build args (carried over from the `template` repo) with `NEXT_PUBLIC_BASE_URL` — the variable the app actually reads.

## Why
Neither `NEXT_PUBLIC_API_URL` nor `NEXT_PUBLIC_VAPID_PUBLIC_KEY` is referenced anywhere in the codebase. `utils/auditLogger.js` reads `NEXT_PUBLIC_BASE_URL` to build absolute API URLs for server-side calls, defaulting to `http://localhost:3000`.

## Changes
- **Dockerfile**: `NEXT_PUBLIC_BASE_URL` build arg (`NEXT_PUBLIC_*` is inlined at build time), dead VAPID arg removed
- **docker-compose.yml**: build arg + runtime fallback use `NEXT_PUBLIC_BASE_URL`
- **example.env**: documents `NEXT_PUBLIC_BASE_URL` (no trailing slash, no `/api` suffix)

Verified: `docker build --build-arg NEXT_PUBLIC_BASE_URL=https://va-stats-test.c4g.dev` succeeds and the value is inlined into the built server bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)