### PR TITLE
Expose app port internally instead of publishing to host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       args:
         # NEXT_PUBLIC_* vars are inlined into the bundle at build time
         - NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL:-}
-    ports:
-      - "${APP_PORT:-3000}:3000"
+    expose:
+      - "3000"
     environment:
       # External MySQL database
       - MYSQL_HOST=${MYSQL_HOST}

--- a/example.env
+++ b/example.env
@@ -19,6 +19,3 @@ GOOGLE_CLIENT_SECRET=your-google-oauth-client-secret
 # server-side. No trailing slash and no /api suffix (the code appends the path).
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
-# --- Docker/Coolify ---
-# Host port the container's 3000 is published on
-APP_PORT=3000


### PR DESCRIPTION
## Problem

`va-stats-test` failed to start with:

```
Bind for 0.0.0.0:3000 failed: port is already allocated
```

The compose file published the container's port 3000 onto the host (`0.0.0.0:3000`). Because `va-stats` and `va-stats-test` run on the same server and both default `APP_PORT` to 3000, they fight over the host port and the second one to start fails.

## Fix

Coolify's proxy routes each resource's FQDN to the container over the internal Docker network — no host port needs to be published. This switches the app service from `ports:` to `expose:` so both resources can coexist, and removes the now-unused `APP_PORT` from `example.env`.

## Follow-up (Coolify UI, not in this PR)

- Set each resource's **Ports Exposes** to `3000` so the proxy knows where to route.
- Remove any stale container still holding host port 3000 from the earlier failed deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)