### PR TITLE
Cache-mount the pnpm store in the Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install dependencies (ignore-scripts skips husky's prepare hook;
 # native packages such as sharp ship prebuilt binaries so no build step is needed)
-RUN pnpm install --frozen-lockfile --ignore-scripts
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --ignore-scripts --store-dir=/pnpm/store
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
Adds a BuildKit cache mount (`id=pnpm-store`, `--store-dir=/pnpm/store`) to the `pnpm install` step so the content-addressable store persists across builds and is shared with other C4G apps (va-partners, template) on the same BuildKit instance.

Why: the Coolify deploy server has slow/flaky registry egress; a warm shared store lets installs reuse already-downloaded packages instead of re-fetching ~1400 packages each build.

Mirrors the verified change in va-partners. No runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)