### PR TITLE
Build and publish the container image on push to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,10 @@ jobs:
           MYSQL_USER: ci
           MYSQL_PASSWORD: ci
         run: |
-          docker compose -f ./docker-compose.yml -p "va-stats-pr-${PR_NUMBER}" up --build -d
+          # docker-compose.build.yml restores the `build:` key that the
+          # production file omits, so the PR is verified against an image built
+          # from this branch rather than the published :latest one.
+          docker compose -f ./docker-compose.yml -f ./docker-compose.build.yml -p "va-stats-pr-${PR_NUMBER}" up --build -d
 
           echo "Waiting for the app to become healthy..."
           for i in {1..60}; do

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,9 +56,7 @@ jobs:
           MYSQL_USER: ci
           MYSQL_PASSWORD: ci
         run: |
-          # docker-compose.build.yml restores the `build:` key that the
-          # production file omits, so the PR is verified against an image built
-          # from this branch rather than the published :latest one.
+          # Build overlay, so the PR runs an image built from this branch.
           docker compose -f ./docker-compose.yml -f ./docker-compose.build.yml -p "va-stats-pr-${PR_NUMBER}" up --build -d
 
           echo "Waiting for the app to become healthy..."

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,16 +1,7 @@
 name: Publish Image
 
-# Builds the application image and pushes it to GHCR so the Coolify host pulls a
-# finished image instead of compiling it. Building on the shared server ties up
-# CPU and disk for every other application on the box; doing it here reduces a
-# deploy to a pull-and-restart.
-#
-# docker-compose.yml has no `build:` key on purpose — see the comment at the top
-# of that file.
-#
-# On push to main this deploys va-stats-test only. Production is promoted
-# manually: set IMAGE_TAG to the commit SHA published here on the `va-stats`
-# Coolify application and redeploy it.
+# Builds the image in CI so the shared Coolify host only pulls and restarts.
+# Push to main deploys va-stats-test; production is promoted by pinning IMAGE_TAG.
 
 on:
   push:
@@ -44,8 +35,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # No build-args: NEXT_PUBLIC_BASE_URL must stay unset at build time so the
-      # same image works against both origins. See Dockerfile.
+      # No build-args, so one image works against both origins. See Dockerfile.
       - name: Build and push app image
         uses: docker/build-push-action@v6
         with:
@@ -72,12 +62,8 @@ jobs:
             echo "on the \`va-stats\` Coolify application and redeploy it."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # Deploying from here (rather than letting Coolify redeploy on git push)
-      # avoids a race where Coolify pulls `:latest` before this workflow has
-      # finished pushing it. Coolify's own auto-deploy is switched off on
-      # va-stats-test for that reason. Skipped automatically until both values
-      # exist. The secret is surfaced through `env` because the `secrets` context
-      # is not available in a step-level `if:`.
+      # Deploy from here, not Coolify's git webhook (switched off), so it cannot
+      # pull `:latest` mid-push. Secrets need `env` because `if:` cannot see them.
       - name: Trigger Coolify deployment (va-stats-test)
         env:
           COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -61,8 +61,8 @@ jobs:
           MYSQL_PASSWORD: smoke
           NEXTAUTH_SECRET: smoke-only-not-a-real-secret
           JWT_SECRET: smoke-only-not-a-real-secret
-          GOOGLE_CLIENT_ID: ''
-          GOOGLE_CLIENT_SECRET: ''
+          GOOGLE_CLIENT_ID: ""
+          GOOGLE_CLIENT_SECRET: ""
         run: |
           docker compose -f docker-compose.yml -p smoke up -d --pull always
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,6 +48,46 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # CI only ever builds the PR head; the squashed commit on main is not
+      # exercised until here. Runs the production compose with no build overlay.
+      - name: Smoke test the published image
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+          # External database; /api/health is DB-independent, so this checks the
+          # published image boots and serves, not that it can reach MySQL.
+          MYSQL_HOST: localhost
+          MYSQL_DATABASE: smoke
+          MYSQL_USER: smoke
+          MYSQL_PASSWORD: smoke
+          NEXTAUTH_SECRET: smoke-only-not-a-real-secret
+          JWT_SECRET: smoke-only-not-a-real-secret
+          GOOGLE_CLIENT_ID: ''
+          GOOGLE_CLIENT_SECRET: ''
+        run: |
+          docker compose -f docker-compose.yml -p smoke up -d --pull always
+
+          app=$(docker compose -p smoke ps -q --all va-stats-app)
+
+          for i in $(seq 1 60); do
+            status=$(docker inspect -f '{{.State.Health.Status}}' "$app")
+            echo "attempt $i: $status"
+            case "$status" in healthy|unhealthy) break ;; esac
+            sleep 2
+          done
+
+          if [ "$(docker inspect -f '{{.State.Health.Status}}' "$app")" != "healthy" ]; then
+            echo "::error::published image never became healthy"
+            docker compose -p smoke logs
+            exit 1
+          fi
+
+          docker exec "$app" wget -qO- http://localhost:3000/api/health
+          echo "OK — pulled image served"
+
+      - name: Stop smoke test stack
+        if: always()
+        run: docker compose -f docker-compose.yml -p smoke down --volumes --remove-orphans || true
+
       - name: Summary
         run: |
           {

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,89 @@
+name: Publish Image
+
+# Builds the application image and pushes it to GHCR so the Coolify host pulls a
+# finished image instead of compiling it. Building on the shared server ties up
+# CPU and disk for every other application on the box; doing it here reduces a
+# deploy to a pull-and-restart.
+#
+# docker-compose.yml has no `build:` key on purpose — see the comment at the top
+# of that file.
+#
+# On push to main this deploys va-stats-test only. Production is promoted
+# manually: set IMAGE_TAG to the commit SHA published here on the `va-stats`
+# Coolify application and redeploy it.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Must be lowercase — GHCR rejects mixed-case image names, and the org is "C4G".
+  # Keep in sync with the `image:` value in docker-compose.yml.
+  IMAGE: ghcr.io/c4g/va-stats
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # No build-args: NEXT_PUBLIC_BASE_URL must stay unset at build time so the
+      # same image works against both origins. See Dockerfile.
+      - name: Build and push app image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          {
+            echo "### Image published"
+            echo ''
+            echo '```'
+            echo "${IMAGE}:latest"
+            echo "${IMAGE}:${GITHUB_SHA}"
+            echo '```'
+            echo ''
+            echo "To promote this build to production, set \`IMAGE_TAG=${GITHUB_SHA}\`"
+            echo "on the \`va-stats\` Coolify application and redeploy it."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Deploying from here (rather than letting Coolify redeploy on git push)
+      # avoids a race where Coolify pulls `:latest` before this workflow has
+      # finished pushing it. Coolify's own auto-deploy is switched off on
+      # va-stats-test for that reason. Skipped automatically until both values
+      # exist. The secret is surfaced through `env` because the `secrets` context
+      # is not available in a step-level `if:`.
+      - name: Trigger Coolify deployment (va-stats-test)
+        env:
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+          COOLIFY_APP_UUID: ${{ vars.COOLIFY_APP_UUID }}
+        if: ${{ env.COOLIFY_TOKEN != '' && env.COOLIFY_APP_UUID != '' }}
+        run: |
+          curl -fsS -X GET \
+            "https://coolify.c4g.dev/api/v1/deploy?uuid=${COOLIFY_APP_UUID}" \
+            -H "Authorization: Bearer ${COOLIFY_TOKEN}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,18 +9,8 @@ FROM base AS builder
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# NEXT_PUBLIC_BASE_URL is deliberately NOT set here.
-#
-# Next.js only substitutes a NEXT_PUBLIC_* variable into the bundle when it is
-# present in the environment at build time. Leaving it unset keeps
-# `process.env.NEXT_PUBLIC_BASE_URL` in the compiled server output as a real
-# runtime lookup, so one published image picks up each environment's own origin
-# from Coolify — va-stats-test and production have different ones.
-#
-# This holds because the value is read on the server only (utils/auditLogger.js,
-# imported solely by pages/api/*). If it is ever read from client code it will be
-# undefined in the browser, and reintroducing the build arg to fix that would
-# re-break the shared image.
+# NEXT_PUBLIC_BASE_URL deliberately unset: Next.js only inlines NEXT_PUBLIC_* vars
+# that exist at build time, so one image works for both test and production.
 
 # Copy package files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,18 @@ FROM base AS builder
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Declare build arguments for Next.js public variables (inlined at build time)
-ARG NEXT_PUBLIC_BASE_URL
-
-# Set environment variables from build args (baked into the client bundle)
-ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
+# NEXT_PUBLIC_BASE_URL is deliberately NOT set here.
+#
+# Next.js only substitutes a NEXT_PUBLIC_* variable into the bundle when it is
+# present in the environment at build time. Leaving it unset keeps
+# `process.env.NEXT_PUBLIC_BASE_URL` in the compiled server output as a real
+# runtime lookup, so one published image picks up each environment's own origin
+# from Coolify — va-stats-test and production have different ones.
+#
+# This holds because the value is read on the server only (utils/auditLogger.js,
+# imported solely by pages/api/*). If it is ever read from client code it will be
+# undefined in the browser, and reintroducing the build arg to fix that would
+# re-break the shared image.
 
 # Copy package files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/README.md
+++ b/README.md
@@ -41,11 +41,56 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
 
-## Deploy on Vercel
+## Deployment (Coolify + GHCR)
 
-This app is deployed on [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+`.github/workflows/publish.yaml` runs on every push to `main` (and on manual
+dispatch). It builds the image, pushes `ghcr.io/c4g/va-stats:latest` and
+`:<commit-sha>`, then triggers a Coolify deployment of **va-stats-test**.
 
-Check out [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+`docker-compose.yml` references that published image and has **no `build:`
+key**, which is what keeps the shared Coolify host from compiling the
+application on every deploy — it only pulls and restarts. Coolify's own git
+auto-deploy is switched off so the workflow is the single trigger, which
+prevents Coolify from pulling `:latest` before the push has finished.
+
+### Environments
+
+| Environment             | Coolify app     | Image tag                                 |
+| ----------------------- | --------------- | ----------------------------------------- |
+| `va-stats-test.c4g.dev` | `va-stats-test` | `latest` (deployed automatically on main) |
+| `va-stats.c4g.dev`      | `va-stats`      | `IMAGE_TAG` pinned to a commit SHA        |
+
+**Promoting to production** is manual and explicit: set `IMAGE_TAG` to the
+commit SHA of a build already verified on va-stats-test in the `va-stats`
+application's Coolify environment variables, then redeploy it. Production then
+runs the exact image that was tested — no rebuild.
+
+### One image, two origins
+
+`NEXT_PUBLIC_BASE_URL` differs per environment, and Next.js normally inlines
+`NEXT_PUBLIC_*` variables at build time, which would tie an image to a single
+origin. The Dockerfile deliberately leaves the variable unset during the build:
+Next only substitutes `NEXT_PUBLIC_*` values that exist at build time, so
+`process.env.NEXT_PUBLIC_BASE_URL` survives in the compiled server output as a
+real runtime lookup and each environment supplies its own value through Coolify.
+
+This works only because the value is read server-side (`utils/auditLogger.js`,
+imported solely by `pages/api/*`). Reading it from client code would yield
+`undefined` in the browser — see the comment in the Dockerfile before changing
+this.
+
+### Required repository/organization configuration
+
+| Name               | Kind     | Purpose                                |
+| ------------------ | -------- | -------------------------------------- |
+| `COOLIFY_TOKEN`    | secret   | Coolify API token (organization-level) |
+| `COOLIFY_APP_UUID` | variable | UUID of the va-stats-test Coolify app  |
+
+### Building locally
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.build.yml up --build -d
+```
 
 ## Code modifications required when changing hosting provider
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,14 +1,5 @@
-# Local/CI build overlay.
-#
-# docker-compose.yml deliberately references the prebuilt GHCR image so the
-# deployment host never compiles the app. This file adds the `build:` key back
-# so the same image can be built from source:
-#
+# Adds the `build:` key that docker-compose.yml omits, for building locally:
 #   docker compose -f docker-compose.yml -f docker-compose.build.yml up --build -d
-#
-# The built image is tagged with the `image:` value from the base file, so the
-# stack runs exactly as it does in production. No build args are passed on
-# purpose — see the NEXT_PUBLIC_BASE_URL comment in Dockerfile.
 services:
   va-stats-app:
     build:

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,16 @@
+# Local/CI build overlay.
+#
+# docker-compose.yml deliberately references the prebuilt GHCR image so the
+# deployment host never compiles the app. This file adds the `build:` key back
+# so the same image can be built from source:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.build.yml up --build -d
+#
+# The built image is tagged with the `image:` value from the base file, so the
+# stack runs exactly as it does in production. No build args are passed on
+# purpose — see the NEXT_PUBLIC_BASE_URL comment in Dockerfile.
+services:
+  va-stats-app:
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,5 @@
-# Production stack — deployed as a Coolify "Docker Compose" resource by both
-# va-stats-test and va-stats (production).
-#
-# The application service references a prebuilt GHCR image and deliberately has
-# no `build:` key: that is what stops the shared Coolify host from compiling the
-# app on every deploy. The image is produced by .github/workflows/publish.yaml
-# on every push to main.
-#
-# One image serves both environments. `IMAGE_TAG` selects which: va-stats-test
-# tracks `latest`, while production pins a specific commit SHA (set IMAGE_TAG in
-# the Coolify application's environment variables) so promoting to production is
-# an explicit choice of an already-tested image.
-#
-# To build the image locally (or in CI), overlay docker-compose.build.yml:
-#   docker compose -f docker-compose.yml -f docker-compose.build.yml up --build -d
+# Production stack for both va-stats-test and va-stats. No `build:` key on purpose
+# — publish.yaml builds the image; IMAGE_TAG picks which build each app runs.
 services:
   # Next.js application. The database is an external MySQL instance, so it is
   # NOT managed here — connection details are provided via environment variables.
@@ -33,9 +20,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
-      # Public config. Read at runtime, NOT baked into the image — see the
-      # comment in Dockerfile. This is what lets one image serve both
-      # va-stats-test and production, which have different origins.
+      # Read at runtime, not baked in — see Dockerfile.
       - NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL:-}
     command: node server.js
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,23 @@
+# Production stack — deployed as a Coolify "Docker Compose" resource by both
+# va-stats-test and va-stats (production).
+#
+# The application service references a prebuilt GHCR image and deliberately has
+# no `build:` key: that is what stops the shared Coolify host from compiling the
+# app on every deploy. The image is produced by .github/workflows/publish.yaml
+# on every push to main.
+#
+# One image serves both environments. `IMAGE_TAG` selects which: va-stats-test
+# tracks `latest`, while production pins a specific commit SHA (set IMAGE_TAG in
+# the Coolify application's environment variables) so promoting to production is
+# an explicit choice of an already-tested image.
+#
+# To build the image locally (or in CI), overlay docker-compose.build.yml:
+#   docker compose -f docker-compose.yml -f docker-compose.build.yml up --build -d
 services:
   # Next.js application. The database is an external MySQL instance, so it is
   # NOT managed here — connection details are provided via environment variables.
   va-stats-app:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        # NEXT_PUBLIC_* vars are inlined into the bundle at build time
-        - NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL:-}
+    image: ghcr.io/c4g/va-stats:${IMAGE_TAG:-latest}
     expose:
       - "3000"
     environment:
@@ -23,8 +33,9 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
-      # Public config (also passed as a build arg above, where it is inlined;
-      # kept here for the server-side runtime fallback)
+      # Public config. Read at runtime, NOT baked into the image — see the
+      # comment in Dockerfile. This is what lets one image serve both
+      # va-stats-test and production, which have different origins.
       - NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL:-}
     command: node server.js
     healthcheck:


### PR DESCRIPTION
## Summary

Same setup as [C4G/template#8](https://github.com/C4G/template/pull/8): move the production image build off the shared Coolify host and into GitHub Actions.

- **`.github/workflows/publish.yaml`** (new) — on push to `main` / `workflow_dispatch`: builds the image, pushes `ghcr.io/c4g/va-stats:latest` and `:<sha>`, then triggers a Coolify deploy of **va-stats-test**.
- **`docker-compose.yml`** — references the published image, **no `build:` key**. That absence is what stops Coolify from compiling on the server; a deploy becomes a pull-and-restart.
- **`docker-compose.build.yml`** (new) — restores the `build:` key for local builds.
- **`.github/workflows/ci.yaml`** — PR runs overlay the build file so they still verify an image built from the branch.
- **`Dockerfile`** — stops baking in `NEXT_PUBLIC_BASE_URL` (see below).
- **`README.md`** — documents the deploy flow, environments, and promotion. Replaces the stale "Deploy on Vercel" section.

## One image, two origins

`NEXT_PUBLIC_BASE_URL` differs per environment (`https://va-stats.c4g.dev` vs `https://va-stats-test.c4g.dev`) and was passed as a build arg, so a single published image could not have served both.

The Dockerfile now leaves it unset at build time. Next.js only substitutes `NEXT_PUBLIC_*` variables that are **present in the environment during the build** (`next/dist/build/webpack/plugins/define-env-plugin.js` → `getNextPublicEnvironmentVariables`), so with it unset the expression survives as a real runtime lookup and each environment supplies its own value through Coolify — which `docker-compose.yml` already passed at runtime.

Verified empirically: built the app with the variable unset and inspected the compiled server output.

```
$ grep -o "process\.env\.NEXT_PUBLIC_BASE_URL" .next/server/pages/api/updateusers.js
process.env.NEXT_PUBLIC_BASE_URL
```

The expression is intact rather than replaced with a literal, so no Docker entrypoint or code change is needed. This holds because the value is read **server-side only** — `utils/auditLogger.js:3`, imported solely by `pages/api/*`, and guarded by `typeof window === "undefined"`. The Dockerfile carries a comment recording that constraint, since reading it from client code would return `undefined` in the browser.

## Environments

| Environment | Coolify app | Image tag |
| --- | --- | --- |
| `va-stats-test.c4g.dev` | `va-stats-test` (`v1084st0j09gwuxnapqkr9xk`) | `latest`, deployed automatically on push to main |
| `va-stats.c4g.dev` | `va-stats` (`gwggx3pjadr1unl07bo471dk`) | `IMAGE_TAG` pinned to a commit SHA, deployed manually |

Production promotion is explicit: set `IMAGE_TAG` to a SHA already verified on va-stats-test, then redeploy. Production runs the exact image that was tested rather than a rebuild.

## Already applied outside this PR

- Coolify git auto-deploy **disabled** on `va-stats-test` (it was on). Otherwise Coolify's webhook would race the workflow and pull the previous `:latest`. The workflow's API call is now the single trigger. Production already had auto-deploy off.
- `COOLIFY_APP_UUID` repository variable set to `v1084st0j09gwuxnapqkr9xk` (va-stats-test).

## Follow-up required after the first run

The new GHCR package is created **private**. The Coolify host pulls anonymously (no `~/.docker/config.json` on the server), so `ghcr.io/c4g/va-stats` must be set to **public** — matching the existing `ghcr.io/c4g/metro-atlanta-saves-*` and `ghcr.io/c4g/va-dat` packages — or the first deploy will fail to pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)